### PR TITLE
Add ms-teams and olk to knownprocesses

### DIFF
--- a/SharpTokenFinder/Program.cs
+++ b/SharpTokenFinder/Program.cs
@@ -53,7 +53,7 @@ class Program
     const uint PROCESS_VM_READ = 0x0010;
     const string DumpDirectory = "dump";
 
-    static readonly string[] KnownProcesses = { "TEAMS", "WINWORD", "ONENOTE", "POWERPNT", "OUTLOOK", "EXCEL", "ONEDRIVE", "SHAREPOINT" };
+    static readonly string[] KnownProcesses = { "TEAMS", "MS-TEAMS", "OLK", "WINWORD", "ONENOTE", "POWERPNT", "OUTLOOK", "EXCEL", "ONEDRIVE", "SHAREPOINT" };
     static readonly HashSet<string> KnownAudiences = new HashSet<string> { "https://graph.microsoft.com/", "https://outlook.office365.com/", "https://outlook.office.com",
                      "sharepoint.com", "00000003-0000-0000-c000-000000000000"};
 


### PR DESCRIPTION
Hi, cool tool & nice video. The new outlook is named `olk` and on my Win11 machine, teams is now `ms-teams`, so I added those to the list of processes. 